### PR TITLE
#1 expose drawpaths and update jvm to 11

### DIFF
--- a/app/src/main/kotlin/io/getstream/sketchbookdemo/SketchbookScreen.kt
+++ b/app/src/main/kotlin/io/getstream/sketchbookdemo/SketchbookScreen.kt
@@ -19,6 +19,8 @@ package io.getstream.sketchbookdemo
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -33,7 +35,15 @@ fun SketchbookScreen(
     modifier: Modifier,
     controller: SketchbookController
 ) {
+
+
+
     Box(modifier = modifier) {
+        Button(onClick = {
+            println(controller.drawPaths)
+        }) {
+            Text("Show draw paths value")
+        }
         Image(
             modifier = Modifier
                 .matchParentSize()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,4 @@
+
 plugins {
     `kotlin-dsl`
 }
@@ -5,3 +6,6 @@ plugins {
 repositories {
     mavenCentral()
 }
+
+
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 08 12:11:55 KST 2022
+#Tue Aug 26 17:28:17 WIB 2025
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/sketchbook/build.gradle
+++ b/sketchbook/build.gradle
@@ -30,9 +30,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
+
+
 
     composeOptions {
         kotlinCompilerExtensionVersion Versions.COMPOSE_COMPILER
@@ -40,6 +42,7 @@ android {
 
     kotlinOptions {
         jvmTarget = '11'
+
     }
 
     lintOptions {
@@ -47,12 +50,17 @@ android {
     }
 }
 
+
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions.freeCompilerArgs += [
             "-Xexplicit-api=strict",
             "-Xopt-in=androidx.compose.ui.ExperimentalComposeUiApi"
     ]
 }
+
+
+
+
 
 dependencies {
     implementation Dependencies.androidxCoreKtx

--- a/sketchbook/src/main/kotlin/io/getstream/sketchbook/SketchbookController.kt
+++ b/sketchbook/src/main/kotlin/io/getstream/sketchbook/SketchbookController.kt
@@ -105,7 +105,11 @@ public class SketchbookController {
     public val isEraseMode: State<Boolean> = _isEraseMode
 
     /** Stack of the drawn [Path]s. */
-    internal val drawPaths = Stack<SketchPath>()
+    private val _drawPaths = Stack<SketchPath>()
+
+    /** Expose read-only list of paths */
+    public val drawPaths: List<SketchPath>
+        get() = _drawPaths.toList()
 
     /** Stack of the redo [Path]s. */
     private val redoPaths = Stack<SketchPath>()
@@ -198,12 +202,12 @@ public class SketchbookController {
 
     /** Draws a [Path] with the current [Paint]. */
     public fun addDrawPath(path: Path) {
-        drawPaths.add(SketchPath(path, Paint().copy(currentPaint)))
+        _drawPaths.add(SketchPath(path, Paint().copy(currentPaint)))
     }
 
     /** Draws a [Path] with the current [Paint]. */
     public fun addDrawPath(path: Path, paint: Paint) {
-        drawPaths.add(SketchPath(path, Paint().copy(paint)))
+        _drawPaths.add(SketchPath(path, Paint().copy(paint)))
     }
 
     internal fun clearRedoPath() {
@@ -218,7 +222,7 @@ public class SketchbookController {
     /** Executes undo the drawn path if possible. */
     public fun undo() {
         if (canUndo.value) {
-            redoPaths.push(drawPaths.pop())
+            redoPaths.push(_drawPaths.pop())
             reviseTick.value++
             updateRevised()
         }
@@ -227,7 +231,7 @@ public class SketchbookController {
     /** Executes redo the drawn path if possible. */
     public fun redo() {
         if (canRedo.value) {
-            drawPaths.push(redoPaths.pop())
+            _drawPaths.push(redoPaths.pop())
             reviseTick.value++
             updateRevised()
         }
@@ -258,7 +262,7 @@ public class SketchbookController {
 
     /** Clear the drawn paths and redo paths on canvas.. */
     public fun clearPaths() {
-        drawPaths.clear()
+        _drawPaths.clear()
         redoPaths.clear()
         updateRevised()
         reviseTick.value++

--- a/sketchbook/src/main/kotlin/io/getstream/sketchbook/internal/SketchPath.kt
+++ b/sketchbook/src/main/kotlin/io/getstream/sketchbook/internal/SketchPath.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.Path
 
 /** Wrapper class to contain [Path] and [Paint]. */
-internal data class SketchPath(
+public data class SketchPath(
     val path: Path,
     val paint: Paint
 )


### PR DESCRIPTION
### 🎯 Goal
Make the `drawPaths` is accessible via its controller. So we can use that for another purpose e.g: saving it state to storage etc, and re-import it again. 

Plus update to jvm target 11.  

As it mentioned here: https://github.com/ydhnwb/sketchbook-compose/issues/1

### ✍️ Explain examples
Access it via `sketchbookController.drawPaths`

